### PR TITLE
Render footer copyright year dynamically at build time

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,3 +1,2 @@
 poweredBy: "Made with ❤️ Powered by Azure Static Web Apps, Hugo & Hextra"
 searchPlaceholder: "Search everything..."
-copyright: "© 2023 Alex Oswald"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,45 @@
+{{- $enableFooterSwitches := .Scratch.Get "enableFooterSwitches" | default false -}}
+{{- $displayThemeToggle := site.Params.theme.displayToggle | default true -}}
+
+{{/* Overrides Hextra's footer to render the copyright year dynamically at build time via now.Year. */}}
+{{- $copyright := printf "© %d Alex Oswald" now.Year -}}
+{{- $poweredBy := (T "poweredBy") | default "Powered by Hextra" -}}
+
+{{- $footerWidth := "max-w-screen-xl" -}}
+{{- with .Site.Params.footer.width -}}
+  {{ if eq . "wide" -}}
+    {{ $footerWidth = "max-w-[90rem]" -}}
+  {{ else if eq . "full" -}}
+    {{ $footerWidth = "max-w-full" -}}
+  {{ end -}}
+{{- end -}}
+
+
+<footer class="hextra-footer bg-gray-100 pb-[env(safe-area-inset-bottom)] dark:bg-neutral-900 print:bg-transparent">
+  {{- if $enableFooterSwitches -}}
+    <div class="mx-auto flex gap-2 py-2 px-4 {{ $footerWidth }}">
+      {{- partial "language-switch.html" (dict "context" .) -}}
+      {{- with $displayThemeToggle }}{{ partial "theme-toggle.html" }}{{ end -}}
+    </div>
+    {{- if or site.IsMultiLingual $displayThemeToggle -}}
+      <hr class="dark:border-neutral-800" />
+    {{- end -}}
+  {{- end -}}
+  <div
+    class="{{ $footerWidth }} mx-auto flex justify-center py-12 pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)] text-gray-600 dark:text-gray-400 md:justify-start"
+  >
+    <div class="flex w-full flex-col items-center sm:items-start">
+      {{- if (.Site.Params.footer.displayPoweredBy | default true) }}<div class="font-semibold">{{ template "theme-credit" $poweredBy }}</div>{{ end }}
+      {{- if .Site.Params.footer.displayCopyright }}<div class="mt-6 text-xs">{{ $copyright | markdownify }}</div>{{ end }}
+    </div>
+  </div>
+</footer>
+
+{{- define "theme-credit" -}}
+  <a class="flex text-sm items-center gap-1 text-current" target="_blank" rel="noopener noreferrer" title="Hextra GitHub Homepage" href="https://github.com/imfing/hextra">
+    <span
+      >{{ . | safeHTML }}
+      {{- partial "utils/icon.html" (dict "name" "hextra" "attributes" "height=1em class=\"inline-block ml-1 align-text-bottom\"") -}}
+    </span>
+  </a>
+{{- end -}}


### PR DESCRIPTION
## Why

The footer copyright was pinned to `© 2023 Alex Oswald` via the `copyright` string in `i18n/en.yaml`, so it showed a stale year regardless of when the site was rebuilt.

## What

- Add `layouts/partials/footer.html` overriding Hextra's footer. It mirrors the theme's v0.6.5 partial verbatim except for the copyright line, which now builds the year with `printf "© %d Alex Oswald" now.Year` at Hugo build time.
- Remove the now-unused `copyright` key from `i18n/en.yaml`.

Because it resolves at build time (no client-side JavaScript, no flash), and Azure Static Web Apps rebuilds on every push/PR to `main`, the year stays current in practice.

## Notes

- Overriding the whole partial means it won't pick up future upstream footer changes from the Hextra theme; the copyright line is the only functional difference.
- Verified locally with Hugo extended 0.117.0 (the version CI uses): the footer renders `© 2026 Alex Oswald`.