### PR TITLE
Fix header logo invisible in dark mode

### DIFF
--- a/hugo.yml
+++ b/hugo.yml
@@ -33,6 +33,10 @@ menu:
         icon: linkedin
 
 params:
+  navbar:
+    logo:
+      path: images/logo.svg
+      dark: images/logo-dark.svg
   comments:
     enable: true
     type: "giscus"


### PR DESCRIPTION
## Why

The hexagon logo to the left of "Alex's Engineering Blog" in the header was invisible in dark mode. It rendered black on the dark background, so it only showed up in light mode.

## Root cause

The Hextra theme's navbar renders two logo images and swaps them by color scheme. The dark-mode image uses `navbar.logo.dark`, which was never configured, so it fell back to the default `images/logo.svg`. That file uses `fill="currentColor"`, which resolves to black when loaded via an `<img>` tag regardless of page theme, so the dark-mode logo was black on dark.

## Fix

Point the dark-mode logo at the white variant the theme already ships (`static/images/logo-dark.svg`, `fill="white"`) by adding a `navbar.logo` block to `hugo.yml`:

```yaml
params:
  navbar:
    logo:
      path: images/logo.svg
      dark: images/logo-dark.svg
```

Light mode keeps the existing black logo; dark mode now uses the white one. No new assets were added; this only wires up an asset the theme already provides.

## Testing

Hugo is not installed in this environment, so a local build/preview was not run. The change is a documented Hextra config option, the YAML was validated, and the referenced `logo-dark.svg` is served from the theme module's static directory (same path root as the currently-working `logo.svg`). Recommend a quick `hugo server` dark-mode toggle to visually confirm.