### PR TITLE
ci: bump checkout and setup-go actions to Node 24 runtime

### DIFF
--- a/.github/workflows/azure-static-web-apps-salmon-ground-05ba16610.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-ground-05ba16610.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
       # Build Hugo ourselves so we control the (extended) binary and Go toolchain.
       # SWA's built-in Oryx build ships an incompatible Hugo that crashes with a
       # GLIBC mismatch, so we prebuild and deploy with skip_app_build below.
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22"
       - name: Setup Hugo


### PR DESCRIPTION
## Why

The Azure Static Web Apps deploy workflow was triggering GitHub's Node 20 deprecation warning. Actions bundling the Node 20 runtime will start failing once Node 20 is removed from runners (full removal scheduled for September 2026), so the pinned action versions needed bumping to majors that run on `node24`.

## What changed

- `actions/checkout` v4 -> v7
- `actions/setup-go` v5 -> v6

Both new majors ship with the `node24` runtime, which clears the deprecation warning.

## Notes

- `peaceiris/actions-hugo@v3` already runs on `node24`, so it was left as-is.
- `Azure/static-web-apps-deploy@v1` is a Docker container action (no Node runtime), so it is unaffected.
- No behavioral changes to the build or deploy steps; this is purely a runtime/action-version bump.