### PR TITLE
Fix SWA deploy failure from invalid skip_api_build input

### DIFF
--- a/.github/workflows/azure-static-web-apps-salmon-ground-05ba16610.yml
+++ b/.github/workflows/azure-static-web-apps-salmon-ground-05ba16610.yml
@@ -52,7 +52,6 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "" # Already built; do not run Oryx
           skip_app_build: true
-          skip_api_build: true
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
## Why

The Build and Deploy job was failing with:

```
Unexpected input(s) 'skip_api_build', valid inputs are ['entryPoint', 'args', 'action', 'app_location', 'azure_static_web_apps_api_token', 'api_build_command', 'api_location', 'app_artifact_location', 'output_location', 'app_build_command', 'repo_token', 'routes_location', 'skip_app_build']
```

The `Azure/static-web-apps-deploy@v1` action does not accept a `skip_api_build` input, so its presence broke the deploy step.

## What

Removed the `skip_api_build: true` line from the `Build And Deploy` step. Since `api_location` is empty there is no API to build, so the input served no purpose. The valid `skip_app_build: true` remains in place to keep SWA from re-running Oryx on the prebuilt Hugo output.