### PR TITLE
Update About Me with team's hardware validation work

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -10,6 +10,8 @@ I'm Alex, and I'm a Full Stack Software Engineer & Electrical Engineer. I'm a So
 
 Curious what I've been working on? Checkout Microsoft's new [Copilot+ PCs](https://www.microsoft.com/en-us/windows/copilot-plus-pcs) that I helped create!
 
+My team built a test framework that validates pre-release engineering hardware, making sure the drivers for new SoCs work well with Windows and deliver a great experience. We're validating AI workloads on Windows PCs and validating SoCs on Windows to power the future AI developer.
+
 Along with my day job, I run Oswald Technologies in my spare time. For 10 years from 2013 to October 2023 my business provided [TireDispatcher](https://tiredispatcher.com). TireDispatcher is Software as a Service (SaaS) that helps commercial tire companies keep track of their mobile services. Some customers included [GCR Tires & Service](https://www.gcrtires.com/), [Continental Tire](https://www.continentaltire.com/), [Les Schwab Tire Center](https://www.lesschwab.com/), [Kal Tire](https://www.kaltire.com/), [Conlan Tire](https://www.conlantire.com/), and [Best One Tire](https://www.bestonetire.com/).
 
 ### Education


### PR DESCRIPTION
## Why

The About Me page didn't describe what my team actually works on. This adds a short paragraph so visitors understand the space I work in day to day.

## What changed

Added a paragraph to `content/about/_index.md` covering:

- The test framework the team built to validate pre-release engineering hardware
- Making sure drivers for new SoCs work well with Windows for a good experience
- Validating AI workloads on Windows PCs
- Validating SoCs on Windows to power the future AI developer

Content-only change to the Hugo `about` section; no layout or config changes.